### PR TITLE
Improvement/pagination logic to remove duplicate transaction hash from wallet txns

### DIFF
--- a/webapp/src/components/Pagination/index.tsx
+++ b/webapp/src/components/Pagination/index.tsx
@@ -15,6 +15,7 @@ interface IPaginationComponentProps {
   label?: string;
   handlePageClick: (index: number) => void;
   showNexOnly?: boolean;
+  disableNext?: boolean;
 }
 
 const PaginationComponent: React.FunctionComponent<IPaginationComponentProps> = (
@@ -63,6 +64,7 @@ const PaginationComponent: React.FunctionComponent<IPaginationComponentProps> = 
           <PaginationLink
             next
             onClick={(e) => props.handlePageClick(currentPage + 1)}
+            disabled={props.disableNext}
           >
             <MdChevronRight />
           </PaginationLink>

--- a/webapp/src/components/Pagination/index.tsx
+++ b/webapp/src/components/Pagination/index.tsx
@@ -14,19 +14,28 @@ interface IPaginationComponentProps {
   pagesCount: number;
   label?: string;
   handlePageClick: (index: number) => void;
+  showNexOnly?: boolean;
 }
 
 const PaginationComponent: React.FunctionComponent<IPaginationComponentProps> = (
   props: IPaginationComponentProps
 ) => {
   const paginatedItems = (currentPage: number, pagesCount: number) => {
-    return fetchPageNumbers(currentPage, pagesCount, 1).map(pageNumber => (
-      <PaginationItem key={pageNumber} active={pageNumber === currentPage}>
-        <PaginationLink onClick={e => props.handlePageClick(pageNumber)}>
-          {pageNumber}
+    return props.showNexOnly ? (
+      <PaginationItem key={currentPage} active={true}>
+        <PaginationLink onClick={(e) => props.handlePageClick(currentPage)}>
+          {currentPage}
         </PaginationLink>
       </PaginationItem>
-    ));
+    ) : (
+      fetchPageNumbers(currentPage, pagesCount, 1).map((pageNumber) => (
+        <PaginationItem key={pageNumber} active={pageNumber === currentPage}>
+          <PaginationLink onClick={(e) => props.handlePageClick(pageNumber)}>
+            {pageNumber}
+          </PaginationLink>
+        </PaginationItem>
+      ))
+    );
   };
 
   const { currentPage, pagesCount, label } = props;
@@ -34,15 +43,17 @@ const PaginationComponent: React.FunctionComponent<IPaginationComponentProps> = 
     <div className='d-flex justify-content-between align-items-center mt-3'>
       <div>{label}</div>
       <Pagination className={styles.pagination}>
-        <PaginationItem disabled={currentPage <= 1}>
-          <PaginationLink first onClick={e => props.handlePageClick(1)}>
-            <MdFirstPage />
-          </PaginationLink>
-        </PaginationItem>
+        {!props.showNexOnly && (
+          <PaginationItem disabled={currentPage <= 1}>
+            <PaginationLink first onClick={(e) => props.handlePageClick(1)}>
+              <MdFirstPage />
+            </PaginationLink>
+          </PaginationItem>
+        )}
         <PaginationItem disabled={currentPage <= 1}>
           <PaginationLink
             previous
-            onClick={e => props.handlePageClick(currentPage - 1)}
+            onClick={(e) => props.handlePageClick(currentPage - 1)}
           >
             <MdChevronLeft />
           </PaginationLink>
@@ -51,16 +62,21 @@ const PaginationComponent: React.FunctionComponent<IPaginationComponentProps> = 
         <PaginationItem disabled={currentPage >= pagesCount}>
           <PaginationLink
             next
-            onClick={e => props.handlePageClick(currentPage + 1)}
+            onClick={(e) => props.handlePageClick(currentPage + 1)}
           >
             <MdChevronRight />
           </PaginationLink>
         </PaginationItem>
-        <PaginationItem disabled={currentPage >= pagesCount}>
-          <PaginationLink last onClick={e => props.handlePageClick(pagesCount)}>
-            <MdLastPage />
-          </PaginationLink>
-        </PaginationItem>
+        {!props.showNexOnly && (
+          <PaginationItem disabled={currentPage >= pagesCount}>
+            <PaginationLink
+              last
+              onClick={(e) => props.handlePageClick(pagesCount)}
+            >
+              <MdLastPage />
+            </PaginationLink>
+          </PaginationItem>
+        )}
       </Pagination>
     </div>
   );

--- a/webapp/src/constants/configs.ts
+++ b/webapp/src/constants/configs.ts
@@ -12,6 +12,7 @@ export const UNPARSED_ADDRESS = 'Unparsed Address';
 export const BLOCK_PAGE_SIZE = 10;
 export const BLOCK_TXN_PAGE_SIZE = 10;
 export const WALLET_TXN_PAGE_SIZE = 5;
+export const MAX_WALLET_TXN_PAGE_SIZE = 200;
 export const PAYMENT_REQ_PAGE_SIZE = 5;
 export const QUEUE_CONCURRENCY = 5;
 export const BALANCE_CRON_DELAY_TIME = 300000;

--- a/webapp/src/containers/WalletPage/components/WalletTxns/index.tsx
+++ b/webapp/src/containers/WalletPage/components/WalletTxns/index.tsx
@@ -118,6 +118,7 @@ const WalletTxns: React.FunctionComponent<WalletTxnsProps> = (
             currentPage={currentPage}
             pagesCount={pagesCount}
             handlePageClick={fetchData}
+            showNexOnly
           />
         </>
       ) : (

--- a/webapp/src/containers/WalletPage/components/WalletTxns/index.tsx
+++ b/webapp/src/containers/WalletPage/components/WalletTxns/index.tsx
@@ -22,7 +22,11 @@ interface WalletTxnsProps {
     height: number;
   }[];
   walletTxnCount: number;
-  fetchWalletTxns: (currentPage: number, pageSize: number) => void;
+  fetchWalletTxns: (
+    currentPage: number,
+    pageSize: number,
+    intialLoad: boolean
+  ) => void;
   stopPagination: boolean;
 }
 
@@ -34,7 +38,7 @@ const WalletTxns: React.FunctionComponent<WalletTxnsProps> = (
   const { walletTxnCount: total, walletTxns, stopPagination } = props;
 
   useEffect(() => {
-    props.fetchWalletTxns(currentPage, pageSize);
+    props.fetchWalletTxns(currentPage, pageSize, true);
   }, []);
 
   const getTxnsTypeIcon = (type: string) => {
@@ -145,8 +149,8 @@ const mapStateToProps = (state) => {
 };
 
 const mapDispatchToProps = {
-  fetchWalletTxns: (currentPage, pageSize) =>
-    fetchWalletTxnsRequest({ currentPage, pageSize }),
+  fetchWalletTxns: (currentPage, pageSize, intialLoad) =>
+    fetchWalletTxnsRequest({ currentPage, pageSize, intialLoad }),
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(WalletTxns);

--- a/webapp/src/containers/WalletPage/components/WalletTxns/index.tsx
+++ b/webapp/src/containers/WalletPage/components/WalletTxns/index.tsx
@@ -23,6 +23,7 @@ interface WalletTxnsProps {
   }[];
   walletTxnCount: number;
   fetchWalletTxns: (currentPage: number, pageSize: number) => void;
+  stopPagination: boolean;
 }
 
 const WalletTxns: React.FunctionComponent<WalletTxnsProps> = (
@@ -30,6 +31,7 @@ const WalletTxns: React.FunctionComponent<WalletTxnsProps> = (
 ) => {
   const [currentPage, handlePageChange] = useState(1);
   const pageSize = WALLET_TXN_PAGE_SIZE;
+  const { walletTxnCount: total, walletTxns, stopPagination } = props;
 
   useEffect(() => {
     props.fetchWalletTxns(currentPage, pageSize);
@@ -47,7 +49,6 @@ const WalletTxns: React.FunctionComponent<WalletTxnsProps> = (
     handlePageChange(pageNumber);
   };
 
-  const { walletTxnCount: total, walletTxns } = props;
   const pagesCount = Math.ceil(total / pageSize);
   const from = (currentPage - 1) * pageSize;
   const to = Math.min(total, currentPage * pageSize);
@@ -119,6 +120,7 @@ const WalletTxns: React.FunctionComponent<WalletTxnsProps> = (
             pagesCount={pagesCount}
             handlePageClick={fetchData}
             showNexOnly
+            disableNext={stopPagination}
           />
         </>
       ) : (
@@ -138,6 +140,7 @@ const mapStateToProps = (state) => {
     unit: settings.appConfig.unit,
     walletTxns: wallet.walletTxns,
     walletTxnCount: wallet.walletTxnCount,
+    stopPagination: wallet.stopPagination,
   };
 };
 

--- a/webapp/src/containers/WalletPage/reducer.tsx
+++ b/webapp/src/containers/WalletPage/reducer.tsx
@@ -11,6 +11,8 @@ export const initialState = {
   walletTxns: [],
   walletTxnCount: 0,
   isWalletTxnsLoading: false,
+  totalFetchedTxns: [],
+  walletPageCounter: 1,
   receivedData: {
     amountToReceive: '',
     amountToReceiveDisplayed: 0,
@@ -48,7 +50,9 @@ const configSlice = createSlice({
     },
     fetchWalletTxnsSuccess(state, action) {
       state.walletTxns = action.payload.walletTxns;
+      state.totalFetchedTxns = action.payload.totalFetchedTxns;
       state.walletTxnCount = action.payload.walletTxnCount;
+      state.walletPageCounter = action.payload.walletPageCounter;
       state.isWalletTxnsLoading = false;
     },
     fetchWalletTxnsFailure(state, action) {

--- a/webapp/src/containers/WalletPage/reducer.tsx
+++ b/webapp/src/containers/WalletPage/reducer.tsx
@@ -13,6 +13,7 @@ export const initialState = {
   isWalletTxnsLoading: false,
   totalFetchedTxns: [],
   walletPageCounter: 1,
+  stopPagination: false,
   receivedData: {
     amountToReceive: '',
     amountToReceiveDisplayed: 0,
@@ -54,6 +55,7 @@ const configSlice = createSlice({
       state.walletTxnCount = action.payload.walletTxnCount;
       state.walletPageCounter = action.payload.walletPageCounter;
       state.isWalletTxnsLoading = false;
+      state.stopPagination = false;
     },
     fetchWalletTxnsFailure(state, action) {
       state.walletTxns = [];
@@ -100,6 +102,9 @@ const configSlice = createSlice({
       state.isPendingBalanceFetching = false;
       state.isPendingBalanceError = action.payload;
     },
+    stopWalletTxnPagination(state) {
+      state.stopPagination = true;
+    },
   },
 });
 
@@ -127,6 +132,7 @@ export const {
   fetchPendingBalanceRequest,
   fetchPendingBalanceSuccess,
   fetchPendingBalanceFailure,
+  stopWalletTxnPagination,
 } = actions;
 
 export default reducer;

--- a/webapp/src/containers/WalletPage/saga.tsx
+++ b/webapp/src/containers/WalletPage/saga.tsx
@@ -105,11 +105,11 @@ export function* fetchPayments() {
 }
 
 function* fetchWalletTxns(action) {
-  const { currentPage: pageNo, pageSize } = action.payload;
+  const { currentPage: pageNo, pageSize, intialLoad } = action.payload;
   const { totalFetchedTxns, walletTxnCount, walletPageCounter } = yield select(
     (state) => state.wallet
   );
-  if (totalFetchedTxns.length <= (pageNo - 1) * pageSize) {
+  if (totalFetchedTxns.length <= (pageNo - 1) * pageSize || intialLoad) {
     yield put(stopWalletTxnPagination());
     queue.push(
       {

--- a/webapp/src/containers/WalletPage/saga.tsx
+++ b/webapp/src/containers/WalletPage/saga.tsx
@@ -22,6 +22,7 @@ import {
   fetchPendingBalanceRequest,
   fetchPendingBalanceSuccess,
   fetchPendingBalanceFailure,
+  stopWalletTxnPagination,
 } from './reducer';
 import {
   handelGetPaymentRequest,
@@ -109,6 +110,7 @@ function* fetchWalletTxns(action) {
     (state) => state.wallet
   );
   if (totalFetchedTxns.length <= (pageNo - 1) * pageSize) {
+    yield put(stopWalletTxnPagination());
     queue.push(
       {
         methodName: handelFetchWalletTxns,

--- a/webapp/src/containers/WalletPage/saga.tsx
+++ b/webapp/src/containers/WalletPage/saga.tsx
@@ -1,5 +1,5 @@
-import { call, put, takeLatest } from 'redux-saga/effects';
-import * as  log from '../../utils/electronLogger';
+import { call, put, takeLatest, select } from 'redux-saga/effects';
+import * as log from '../../utils/electronLogger';
 import {
   fetchPaymentRequest,
   fetchPaymentRequestsSuccess,
@@ -35,7 +35,10 @@ import {
 import queue from '../../worker/queue';
 import store from '../../app/rootStore';
 import showNotification from '../../utils/notifications';
+import { paginate } from '../../utils/utility';
 import { I18n } from 'react-redux-i18n';
+import uniqBy from 'lodash/uniqBy';
+import { MAX_WALLET_TXN_PAGE_SIZE } from '../../constants';
 
 function fetchWalletBalance() {
   queue.push(
@@ -100,24 +103,50 @@ export function* fetchPayments() {
   }
 }
 
-function fetchWalletTxns(action) {
+function* fetchWalletTxns(action) {
   const { currentPage: pageNo, pageSize } = action.payload;
-  queue.push(
-    { methodName: handelFetchWalletTxns, params: [pageNo, pageSize] },
-    (err, result) => {
-      if (err) {
-        store.dispatch(fetchWalletTxnsFailure(err.message));
-        log.error(err);
-        return;
-      }
-      if (result && result.walletTxns)
-        store.dispatch(fetchWalletTxnsSuccess({ ...result }));
-      else {
-        showNotification(I18n.t('alerts.walletTxnsFailure'), 'No data found');
-        store.dispatch(fetchWalletTxnsFailure('No data found'));
-      }
-    }
+  const { totalFetchedTxns, walletTxnCount, walletPageCounter } = yield select(
+    (state) => state.wallet
   );
+  if (totalFetchedTxns.length <= (pageNo - 1) * pageSize) {
+    queue.push(
+      {
+        methodName: handelFetchWalletTxns,
+        params: [walletPageCounter, MAX_WALLET_TXN_PAGE_SIZE],
+      },
+      (err, result) => {
+        if (err) {
+          store.dispatch(fetchWalletTxnsFailure(err.message));
+          log.error(err);
+          return;
+        }
+        if (result && result.walletTxns) {
+          const distinct = uniqBy(result.walletTxns, 'txnId');
+          const totalFetched = totalFetchedTxns.concat(distinct);
+          store.dispatch(
+            fetchWalletTxnsSuccess({
+              walletTxnCount: result.walletTxnCount,
+              totalFetchedTxns: totalFetched,
+              walletTxns: paginate(totalFetched, pageSize, pageNo),
+              walletPageCounter: walletPageCounter + 1,
+            })
+          );
+        } else {
+          showNotification(I18n.t('alerts.walletTxnsFailure'), 'No data found');
+          store.dispatch(fetchWalletTxnsFailure('No data found'));
+        }
+      }
+    );
+  } else {
+    yield put(
+      fetchWalletTxnsSuccess({
+        totalFetchedTxns,
+        walletTxnCount,
+        walletTxns: paginate(totalFetchedTxns, pageSize, pageNo),
+        walletPageCounter,
+      })
+    );
+  }
 }
 
 function fetchSendData() {

--- a/webapp/src/utils/utility.ts
+++ b/webapp/src/utils/utility.ts
@@ -103,7 +103,7 @@ export const getTxnDetails = async (txns): Promise<ITxn[]> => {
     let height = -1;
     const fee = txn.category === 'send' ? txn.fee : 0;
     const blockHash = txn.blockhash || '';
-    if(blockHash !== ''){
+    if (blockHash !== '') {
       const block = await rpcClient.getBlock(blockHash, 1);
       height = block.height;
     }
@@ -271,4 +271,9 @@ export const filterByValue = (array, query) => {
       return stringer.toLowerCase().includes(query.toLowerCase());
     })
   );
+};
+
+export const paginate = (array, pageSize, pageNo) => {
+  // human-readable page numbers usually start with 1, so we reduce 1 in the first argument
+  return array.slice((pageNo - 1) * pageSize, pageNo * pageSize);
 };


### PR DESCRIPTION
- Add a logic to remove duplicate transaction id from wallet txn list.
- Fetch 200 transaction at a time.
- Disable pagination next button while loading new data.