### PR TITLE
Fix: remove label as required in create new receive page

### DIFF
--- a/webapp/src/constants/settings.ts
+++ b/webapp/src/constants/settings.ts
@@ -23,3 +23,4 @@ export const DEFI_CHAIN_HOMEPAGE = `https://www.defichain.io/`;
 export const PACKAGE_VERSION = version;
 export const PACKAGE_NAME = name;
 export const APP_TITLE = 'DeFi Blockchain';
+export const SITE_URL = 'https://defichain.com/';

--- a/webapp/src/containers/Sidebar/index.tsx
+++ b/webapp/src/containers/Sidebar/index.tsx
@@ -25,7 +25,7 @@ import {
   // EXCHANGE_PATH,
   // HELP_PATH,
   SETTING_PATH,
-  DEFI_CHAIN_HOMEPAGE,
+  SITE_URL,
 } from '../../constants';
 import styles from './Sidebar.module.scss';
 import OpenNewTab from '../../utils/openNewTab';
@@ -122,7 +122,7 @@ const Sidebar: React.FunctionComponent<SidebarProps> = (props) => {
           </NavItem>
           <NavItem className={styles.navItem}>
             <NavLink
-              onClick={() => OpenNewTab(DEFI_CHAIN_HOMEPAGE)}
+              onClick={() => OpenNewTab(SITE_URL)}
               className={styles.navLink}
               activeClassName={styles.active}
             >

--- a/webapp/src/containers/WalletPage/__tests__/__snapshots__/createNewAddressPage.test.tsx.snap
+++ b/webapp/src/containers/WalletPage/__tests__/__snapshots__/createNewAddressPage.test.tsx.snap
@@ -374,14 +374,12 @@ exports[`PaymentRequests component should check for snapshot 1`] = `
                   </Button>
                   <Button
                     color="primary"
-                    disabled={true}
                     onClick={[Function]}
                     tag="button"
                   >
                     <button
                       aria-label={null}
-                      className="btn btn-primary disabled"
-                      disabled={true}
+                      className="btn btn-primary"
                       onClick={[Function]}
                       type="button"
                     >

--- a/webapp/src/containers/WalletPage/components/ReceivePage/CreateNewAddressPage/index.tsx
+++ b/webapp/src/containers/WalletPage/components/ReceivePage/CreateNewAddressPage/index.tsx
@@ -111,7 +111,7 @@ const CreateNewAddressPage: React.FunctionComponent<CreateNewAddressPageProps> =
             >
               {I18n.t('containers.wallet.receivePage.cancel')}
             </Button>
-            <Button color='primary' onClick={onSubmit} disabled={!label}>
+            <Button color='primary' onClick={onSubmit}>
               {I18n.t('containers.wallet.receivePage.createButton')}
             </Button>
           </div>


### PR DESCRIPTION
- Remove label as required parameter from create new receive page
- change help page redirection url to defichain.com