### PR TITLE
Feature/import wallet

### DIFF
--- a/electron-app/src/controllers/wallets.ts
+++ b/electron-app/src/controllers/wallets.ts
@@ -5,9 +5,8 @@ import { MENU_BACKUP_WALLET, MENU_IMPORT_WALLET } from '../constants';
 export default class Wallet {
   async load(bw: Electron.BrowserWindow) {
     try {
-      const filter = [{ name: 'Wallet', extensions: ['dat'] }];
       const dialogManager = new DialogManager();
-      const paths = await dialogManager.getFilePath(filter);
+      const paths = await dialogManager.getFilePath();
       bw.webContents.send(MENU_IMPORT_WALLET, { paths });
     } catch (err) {
       log.error(err);
@@ -21,7 +20,7 @@ export default class Wallet {
       if (!paths.length) {
         throw new Error('No valid path available');
       }
-      bw.webContents.send(MENU_BACKUP_WALLET, { paths });
+      bw.webContents.send(MENU_BACKUP_WALLET, { paths: paths[0] });
     } catch (err) {
       log.error(err);
     }

--- a/electron-app/src/controllers/wallets.ts
+++ b/electron-app/src/controllers/wallets.ts
@@ -16,11 +16,11 @@ export default class Wallet {
   async backup(bw: Electron.BrowserWindow) {
     try {
       const dialogManager = new DialogManager();
-      const paths = await dialogManager.getDirectoryPath();
+      const paths = await dialogManager.saveFilePath();
       if (!paths.length) {
         throw new Error('No valid path available');
       }
-      bw.webContents.send(MENU_BACKUP_WALLET, { paths: paths[0] });
+      bw.webContents.send(MENU_BACKUP_WALLET, { paths });
     } catch (err) {
       log.error(err);
     }

--- a/electron-app/src/menus/index.ts
+++ b/electron-app/src/menus/index.ts
@@ -8,13 +8,13 @@ export default class AppMenu {
       {
         label: 'Wallet',
         submenu: [
-          // {
-          //   label: 'Import Wallet',
-          //   click(item, bw) {
-          //     const wallet = new Wallet();
-          //     wallet.load(bw);
-          //   },
-          // },
+          {
+            label: 'Import Wallet',
+            click(item, bw) {
+              const wallet = new Wallet();
+              wallet.load(bw);
+            },
+          },
           {
             label: 'Backup Wallet',
             click(item, bw) {

--- a/electron-app/src/services/dialogmanager.ts
+++ b/electron-app/src/services/dialogmanager.ts
@@ -34,4 +34,24 @@ export default class DialogManager {
       throw err;
     }
   }
+
+  async saveFilePath(filters?: { name: string; extensions: string[] }[]) {
+    try {
+      const res = await dialog.showSaveDialog(null, {
+        properties: [
+          'createDirectory',
+          'showOverwriteConfirmation',
+          'treatPackageAsDirectory',
+        ],
+        filters,
+      });
+      if (res.canceled || !res.filePath) {
+        throw new Error('File not selected');
+      }
+      return res.filePath;
+    } catch (err) {
+      log.error(err);
+      throw err;
+    }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "defi-app",
-  "version": "1.0.0-alpha4",
+  "version": "1.0.0-alpha5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "defi-app",
-  "version": "1.0.0",
+  "version": "1.0.0-alpha5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/webapp/src/app/menu.ipcRenderer.ts
+++ b/webapp/src/app/menu.ipcRenderer.ts
@@ -4,7 +4,7 @@ const initMenuIpcRenderers = () => {
   const { ipcRenderer } = window.require('electron');
   ipcRenderer.on(
     'menu-backup-wallet',
-    async (event: any, arg: { paths: string[] }) => {
+    async (event: any, arg: { paths: string }) => {
       const { paths } = arg;
       await backupWallet(paths);
     }

--- a/webapp/src/app/service.tsx
+++ b/webapp/src/app/service.tsx
@@ -6,9 +6,6 @@ import * as log from '../utils/electronLogger';
 import { I18n } from 'react-redux-i18n';
 import { isBlockchainStarted } from '../containers/RpcConfiguration/service';
 import { eventChannel } from 'redux-saga';
-import { MAINNET, TESTNET } from '../constants';
-import isEmpty from 'lodash/isEmpty';
-import store from '../app/rootStore';
 
 export const getRpcConfig = () => {
   if (isElectron()) {
@@ -47,7 +44,7 @@ export const stopBinary = () => {
 
 export const backupWallet = async (paths: string) => {
   const rpcClient = new RpcClient();
-  const res = await rpcClient.call('', 'dumpwallet', [`${paths}`]);
+  const res = await rpcClient.call('', 'dumpwallet', [paths]);
 
   if (res.status === HttpStatus.OK) {
     return showNotification(

--- a/webapp/src/app/service.tsx
+++ b/webapp/src/app/service.tsx
@@ -47,17 +47,7 @@ export const stopBinary = () => {
 
 export const backupWallet = async (paths: string) => {
   const rpcClient = new RpcClient();
-  let backupWalletName = 'wallet';
-  const {
-    syncstatus: { blockChainInfo },
-  } = store.getState();
-
-  if (!isEmpty(blockChainInfo)) {
-    backupWalletName = `${blockChainInfo.chain}-wallet`;
-  }
-  const res = await rpcClient.call('', 'dumpwallet', [
-    `${paths}/${backupWalletName}`,
-  ]);
+  const res = await rpcClient.call('', 'dumpwallet', [`${paths}`]);
 
   if (res.status === HttpStatus.OK) {
     return showNotification(

--- a/webapp/src/app/service.tsx
+++ b/webapp/src/app/service.tsx
@@ -6,6 +6,9 @@ import * as log from '../utils/electronLogger';
 import { I18n } from 'react-redux-i18n';
 import { isBlockchainStarted } from '../containers/RpcConfiguration/service';
 import { eventChannel } from 'redux-saga';
+import { MAINNET, TESTNET } from '../constants';
+import isEmpty from 'lodash/isEmpty';
+import store from '../app/rootStore';
 
 export const getRpcConfig = () => {
   if (isElectron()) {
@@ -42,9 +45,20 @@ export const stopBinary = () => {
   return { success: true, data: {} };
 };
 
-export const backupWallet = async (paths: string[]) => {
+export const backupWallet = async (paths: string) => {
   const rpcClient = new RpcClient();
-  const res = await rpcClient.call('', 'backupwallet', paths);
+  let backupWalletName = 'wallet';
+  const {
+    syncstatus: { blockChainInfo },
+  } = store.getState();
+
+  if (!isEmpty(blockChainInfo)) {
+    backupWalletName = `${blockChainInfo.chain}-wallet`;
+  }
+  const res = await rpcClient.call('', 'dumpwallet', [
+    `${paths}/${backupWalletName}`,
+  ]);
+
   if (res.status === HttpStatus.OK) {
     return showNotification(
       I18n.t('alerts.success'),


### PR DESCRIPTION
- Disable menu button for import wallet.
- Use dumpwallet instead of backupwallet rpc call for backing up wallet.
- Add new save dialog box so that user can save a backup file by giving desired name.
- Fix import function earlier it was using wallet.dat now it is importing simple plain text file generated by dumpwallet rpc call.
