### PR TITLE
Improvement/update-balance-continuously

### DIFF
--- a/webapp/src/containers/BlockchainPage/service.tsx
+++ b/webapp/src/containers/BlockchainPage/service.tsx
@@ -77,7 +77,7 @@ export const handelFetchTxns = async (
     txnList.push(parsedTxn);
   }
 
-  //add to cache for future use
+  // add to cache for future use
   const key = toSha256(`${blockNumber} ${pageNo} ${pageSize}`);
   LruCache.put(key, txnList);
 

--- a/webapp/src/containers/SettingsPage/components/SettingsTabFooter/index.tsx
+++ b/webapp/src/containers/SettingsPage/components/SettingsTabFooter/index.tsx
@@ -3,7 +3,7 @@ import { I18n } from 'react-redux-i18n';
 import { Button, Row, Col } from 'reactstrap';
 
 interface SettingsTabsFooterProps {
-  saveChanges: Function;
+  saveChanges: () => void;
   isUnsavedChanges: boolean;
 }
 

--- a/webapp/src/containers/Sidebar/index.tsx
+++ b/webapp/src/containers/Sidebar/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../constants';
 import styles from './Sidebar.module.scss';
 import OpenNewTab from '../../utils/openNewTab';
+import { updateWalletBalanceSchedular } from '../../worker/schedular';
 
 export interface SidebarProps extends RouteComponentProps {
   fetchWalletBalanceRequest: () => void;
@@ -39,6 +40,10 @@ export interface SidebarProps extends RouteComponentProps {
 const Sidebar: React.FunctionComponent<SidebarProps> = (props) => {
   useEffect(() => {
     props.fetchWalletBalanceRequest();
+    const clearWalletBalanceTimer = updateWalletBalanceSchedular();
+    return () => {
+      clearWalletBalanceTimer();
+    };
   }, []);
 
   return (

--- a/webapp/src/containers/SyncStatus/index.tsx
+++ b/webapp/src/containers/SyncStatus/index.tsx
@@ -37,7 +37,7 @@ const SyncStatus: React.FunctionComponent<SyncStatusProps> = (
       props.fetchWalletBalanceRequest();
       props.fetchPendingBalanceRequest();
     }
-  }, [prevIsRestart && !props.isRestart]);
+  }, [prevIsRestart, props.isRestart]);
 
   const {
     latestSyncedBlock,

--- a/webapp/src/containers/WalletPage/index.tsx
+++ b/webapp/src/containers/WalletPage/index.tsx
@@ -13,12 +13,7 @@ import {
 } from './reducer';
 import { WALLET_SEND_PATH, WALLET_RECEIVE_PATH } from '../../constants';
 import { getAmountInSelectedUnit } from '../../utils/utility';
-import {
-  updateWalletBalanceSchedular,
-  updatePendingBalanceSchedular,
-  walletBalanceTimerID,
-  pendingBalanceTimerID,
-} from '../../worker/schedular';
+import { updatePendingBalanceSchedular } from '../../worker/schedular';
 import styles from './WalletPage.module.scss';
 
 interface WalletPageProps {
@@ -35,13 +30,10 @@ const WalletPage: React.FunctionComponent<WalletPageProps> = (
   useEffect(() => {
     props.fetchWalletBalanceRequest();
     props.fetchPendingBalanceRequest();
-
-    updateWalletBalanceSchedular();
-    updatePendingBalanceSchedular();
+    const clearPendingBalanceTimer = updatePendingBalanceSchedular();
 
     return () => {
-      clearInterval(walletBalanceTimerID);
-      clearInterval(pendingBalanceTimerID);
+      clearPendingBalanceTimer();
       clearTimeout(balanceRefreshTimerID);
       clearTimeout(pendingBalRefreshTimerID);
     };

--- a/webapp/src/utils/cutxo.ts
+++ b/webapp/src/utils/cutxo.ts
@@ -8,7 +8,7 @@ const BN = BigNumber.clone({ DECIMAL_PLACES: 8 });
 export const construct = async ({ maximumAmount, maximumCount, feeRate }) => {
   const rpcClient = new RpcClient();
 
-  let unspent = await rpcClient.listUnspent(maximumAmount, maximumCount);
+  const unspent = await rpcClient.listUnspent(maximumAmount, maximumCount);
   const inputsTotal = unspent.length;
 
   if (unspent.length === 0) {
@@ -29,7 +29,7 @@ export const construct = async ({ maximumAmount, maximumCount, feeRate }) => {
   while (!success) {
     let res;
     const unspentSlice = unspent.slice(0, sliceTo);
-    const inputs = unspentSlice.map(u => ({
+    const inputs = unspentSlice.map((u) => ({
       txid: u.txid,
       vout: u.vout,
     }));
@@ -39,10 +39,7 @@ export const construct = async ({ maximumAmount, maximumCount, feeRate }) => {
     const outputs = [{ [address]: amount }];
 
     try {
-      const fR = new BN(feeRate)
-        .times(1024)
-        .div(1e8)
-        .toNumber();
+      const fR = new BN(feeRate).times(1024).div(1e8).toNumber();
       res = await rpcClient.walletCreateFundedPsbt(inputs, outputs, fR);
     } catch (e) {
       if (

--- a/webapp/src/utils/utility.ts
+++ b/webapp/src/utils/utility.ts
@@ -289,3 +289,18 @@ export const getErrorMessage = (errorResponse) => {
   }
   return typeof message === 'string' ? message : JSON.stringify(message);
 };
+
+export const setIntervalSynchronous = (func, delay) => {
+  let intervalFunction;
+  let timeoutId;
+  let clear;
+  clear = () => {
+    clearTimeout(timeoutId);
+  };
+  intervalFunction = () => {
+    func();
+    timeoutId = setTimeout(intervalFunction, delay);
+  };
+  timeoutId = setTimeout(intervalFunction, delay);
+  return clear;
+};

--- a/webapp/src/worker/schedular/updateBalance.ts
+++ b/webapp/src/worker/schedular/updateBalance.ts
@@ -4,30 +4,18 @@ import {
   fetchPendingBalanceRequest,
 } from '../../containers/WalletPage/reducer';
 import { BALANCE_CRON_DELAY_TIME } from '../../constants';
+import { setIntervalSynchronous } from '../../utils/utility';
 
 const walletBalanceSchedular = () => {
-  console.log('wallet balance schedular called');
   store.dispatch(fetchWalletBalanceRequest());
 };
 
 const pendingBalanceSchedular = () => {
-  console.log('pending balance schedular called');
   store.dispatch(fetchPendingBalanceRequest());
 };
 
-export let walletBalanceTimerID;
-export let pendingBalanceTimerID;
+export const updateWalletBalanceSchedular = () =>
+  setIntervalSynchronous(walletBalanceSchedular, BALANCE_CRON_DELAY_TIME);
 
-export const updateWalletBalanceSchedular = () => {
-  walletBalanceTimerID = setInterval(
-    walletBalanceSchedular,
-    BALANCE_CRON_DELAY_TIME
-  );
-};
-
-export const updatePendingBalanceSchedular = () => {
-  pendingBalanceTimerID = setInterval(
-    pendingBalanceSchedular,
-    BALANCE_CRON_DELAY_TIME
-  );
-};
+export const updatePendingBalanceSchedular = () =>
+  setIntervalSynchronous(pendingBalanceSchedular, BALANCE_CRON_DELAY_TIME);


### PR DESCRIPTION
- Remove setInterval as it is very expensive and works asynchronously to the system.
- Instead use Synchronous set interval.
- Add polling of Walletbalance in sidebar instead of wallet page because earlier it is defi-app is polling when user is in walletpage and stop updating new balance if user is move to another tab and now we are updating balance as soon as it is updated on the blockchain.