### PR TITLE
improve UI of update available badge

### DIFF
--- a/webapp/src/app/App.tsx
+++ b/webapp/src/app/App.tsx
@@ -19,8 +19,6 @@ interface AppProps extends RouteComponentProps {
   getRpcConfigsRequest: () => void;
   nodeError: string;
   isFetching: boolean;
-  isErrorModalOpen: boolean;
-  isUpdateModalOpen: boolean;
   isRestart: boolean;
 }
 
@@ -45,8 +43,6 @@ const App: React.FunctionComponent<AppProps> = (props: AppProps) => {
     location,
     getRpcConfigsRequest,
     isRunning,
-    isErrorModalOpen,
-    isUpdateModalOpen,
     nodeError,
     isFetching,
     isRestart,
@@ -67,14 +63,7 @@ const App: React.FunctionComponent<AppProps> = (props: AppProps) => {
   return (
     <>
       {isRunning ? (
-        <div
-          id='app'
-          className={
-            isErrorModalOpen || isUpdateModalOpen
-              ? popoverModelStyles.openErrorModal
-              : ''
-          }
-        >
+        <div id='app'>
           <Helmet>
             <title>DeFi Blockchain Client</title>
           </Helmet>
@@ -113,8 +102,6 @@ const mapStateToProps = ({ app, popover }) => ({
   isRunning: app.isRunning,
   nodeError: app.nodeError,
   isFetching: app.isFetching,
-  isErrorModalOpen: popover.isOpen,
-  isUpdateModalOpen: popover.isUpdateModalOpen,
   isRestart: popover.isReIndexRestart,
 });
 

--- a/webapp/src/components/Badge/index.tsx
+++ b/webapp/src/components/Badge/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { MdInfo } from 'react-icons/md';
+import { I18n } from 'react-redux-i18n';
+import { Button, ButtonProps } from 'reactstrap';
+
+interface BadgeProps extends ButtonProps {
+  baseClass?: string;
+  label: string;
+}
+
+const Badge: React.FunctionComponent<BadgeProps> = (props: BadgeProps) => {
+  return (
+    <div className={props.baseClass}>
+      <Button className='badge' {...props}>
+        <MdInfo />
+        <span>{props.label}</span>
+      </Button>
+    </div>
+  );
+};
+
+export default Badge;

--- a/webapp/src/containers/PopOver/UpdateProgress/ShowUpdateAvailable.tsx
+++ b/webapp/src/containers/PopOver/UpdateProgress/ShowUpdateAvailable.tsx
@@ -17,15 +17,15 @@ const ShowUpdateAvailableComponent = (
   const closing = () => closeModal(closeUpdateAvailable);
   return (
     <>
-      <ModalHeader toggle={closing}>
-        {I18n.t('alerts.showUpdateAvailableHeader')}
-      </ModalHeader>
-      <ModalBody>{I18n.t('alerts.showUpdateAvailableNotice')}</ModalBody>
+      <ModalBody>
+        <h1 className='h4'>{I18n.t('alerts.showUpdateAvailableHeader')}</h1>
+        {I18n.t('alerts.showUpdateAvailableNotice')}
+      </ModalBody>
       <ModalFooter>
         <Button size='sm' color='primary' onClick={showAvailableUpdateResponse}>
           {I18n.t('alerts.yesShowUpdateAvailableButton')}
         </Button>
-        <Button size='sm' onClick={closing}>
+        <Button size='sm' color='link' onClick={closing}>
           {I18n.t('alerts.noShowUpdateAvailableButton')}
         </Button>
       </ModalFooter>

--- a/webapp/src/containers/PopOver/popOver.module.scss
+++ b/webapp/src/containers/PopOver/popOver.module.scss
@@ -30,10 +30,6 @@
   }
 }
 
-.openErrorModal {
-  filter: blur(5px);
-}
-
 @-webkit-keyframes rotation {
   from {
     -webkit-transform: rotate(0deg);

--- a/webapp/src/containers/PopOver/reducer.tsx
+++ b/webapp/src/containers/PopOver/reducer.tsx
@@ -15,7 +15,7 @@ const configSlice = createSlice({
     isReIndexModelOpen: false,
     isReIndexRestart: false,
     isMinimized: false,
-    updateAvailableBadge: true,
+    updateAvailableBadge: false,
   },
   reducers: {
     openErrorModal(state) {

--- a/webapp/src/containers/WalletPage/index.tsx
+++ b/webapp/src/containers/WalletPage/index.tsx
@@ -21,6 +21,7 @@ import { WALLET_SEND_PATH, WALLET_RECEIVE_PATH } from '../../constants';
 import { getAmountInSelectedUnit } from '../../utils/utility';
 import { updatePendingBalanceSchedular } from '../../worker/schedular';
 import styles from './WalletPage.module.scss';
+import Badge from '../../components/Badge';
 
 interface WalletPageProps {
   unit: string;
@@ -74,15 +75,13 @@ const WalletPage: React.FunctionComponent<WalletPageProps> = (
       </Helmet>
       <header className='header-bar'>
         <h1>{I18n.t('containers.wallet.walletPage.wallet')}</h1>
-        {updateAvailableBadge && ( // TODO remove true from reducer
-          <div className='update-available'>
-            <Button className='badge' outline onClick={openUpdatePopUp}>
-              <MdInfo />
-              <span>
-                {I18n.t('containers.wallet.walletPage.updateAvailableLabel')}
-              </span>
-            </Button>
-          </div>
+        {updateAvailableBadge && (
+          <Badge
+            baseClass='update-available'
+            outline
+            onClick={openUpdatePopUp}
+            label={I18n.t('containers.wallet.walletPage.updateAvailableLabel')}
+          />
         )}
         <ButtonGroup>
           <Button to={WALLET_SEND_PATH} tag={RRNavLink} color='link' size='sm'>

--- a/webapp/src/containers/WalletPage/index.tsx
+++ b/webapp/src/containers/WalletPage/index.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { Button, ButtonGroup, Row, Col, Badge } from 'reactstrap';
-import { MdArrowUpward, MdArrowDownward, MdRefresh } from 'react-icons/md';
+import { Button, ButtonGroup, Row, Col } from 'reactstrap';
+import {
+  MdArrowUpward,
+  MdArrowDownward,
+  MdRefresh,
+  MdInfo,
+} from 'react-icons/md';
 import { NavLink as RRNavLink } from 'react-router-dom';
 import StatCard from '../../components/StatCard';
 import WalletTxns from './components/WalletTxns';
@@ -70,12 +75,14 @@ const WalletPage: React.FunctionComponent<WalletPageProps> = (
       <header className='header-bar'>
         <h1>{I18n.t('containers.wallet.walletPage.wallet')}</h1>
         {updateAvailableBadge && ( // TODO remove true from reducer
-          <Button size='sm' color='secondary' outline onClick={openUpdatePopUp}>
-            <Badge color='success' pill>
-              i
-            </Badge>{' '}
-            {I18n.t('containers.wallet.walletPage.updateAvailableLabel')}
-          </Button>
+          <div className='update-available'>
+            <Button className='badge' outline onClick={openUpdatePopUp}>
+              <MdInfo />
+              <span>
+                {I18n.t('containers.wallet.walletPage.updateAvailableLabel')}
+              </span>
+            </Button>
+          </div>
         )}
         <ButtonGroup>
           <Button to={WALLET_SEND_PATH} tag={RRNavLink} color='link' size='sm'>

--- a/webapp/src/scss/_layout.scss
+++ b/webapp/src/scss/_layout.scss
@@ -75,6 +75,33 @@ body {
         text-transform: none;
       }
 
+      .update-available {
+        position: absolute;
+        top: 16px;
+        right: 24px;
+
+        > * {
+          display: block;
+        }
+
+        > .btn {
+          text-transform: none;
+          letter-spacing: 0.21px;
+          font-weight: $font-weight-medium;
+
+          &:hover {
+            color: $gray-900;
+          }
+
+          svg {
+            color: $green;
+            margin-right: 4px;
+            width: 12px;
+            height: 12px;
+          }
+        }
+      }
+
       @include media-breakpoint-down(sm) {
         .btn span {
           display: none;

--- a/webapp/src/translations/languages/en.json
+++ b/webapp/src/translations/languages/en.json
@@ -281,7 +281,7 @@
         "transactions": "Transactions",
         "availableBalance": "Available balance",
         "pending": "Pending",
-        "updateAvailableLabel": "Update Available"
+        "updateAvailableLabel": "Update available"
       },
       "walletTxns": {
         "height": "Height",
@@ -340,10 +340,10 @@
     "updateAppNotice": "You need to restart app to see the new update. Do you want to restart?",
     "yesUpdateAppNotice": "Yes",
     "noUpdateAppNotice": "No",
-    "showUpdateAvailableHeader": "Update available",
-    "showUpdateAvailableNotice": "A new version of Defi app is available. Would you like to update?",
-    "yesShowUpdateAvailableButton": "Yes",
-    "noShowUpdateAvailableButton": "No",
+    "showUpdateAvailableHeader": "An update available is available for DeFi app",
+    "showUpdateAvailableNotice": "Would you like to update?",
+    "yesShowUpdateAvailableButton": "Update",
+    "noShowUpdateAvailableButton": "Not now",
     "startUpdateLabel": "Initiating Update",
     "closeBtnLabel": "Close",
     "downloadingUpdate": "Downloading update",


### PR DESCRIPTION
<img width="346" alt="image" src="https://user-images.githubusercontent.com/791368/93657455-be536a00-fa65-11ea-9873-5b38a8b89d90.png">
<img width="544" alt="image" src="https://user-images.githubusercontent.com/791368/93657492-fce92480-fa65-11ea-9395-f5825d47191e.png">

I changed the "No" option to "Now now" because No would mean the user has rejected the update and the badge should go away. Not now is more appropriate since the user is only temporarily dismissing the popup and they are still expected to eventually update, which is what we want and better for the user.
