### PR TITLE
Fix: backup mainnet wallet.dat in mac and win

### DIFF
--- a/electron-app/src/constants/dirpath.ts
+++ b/electron-app/src/constants/dirpath.ts
@@ -53,4 +53,7 @@ export const REGTEST_BASE_FOLDER = path.join(
   'wallets'
 );
 
-export const MAINNET_BASE_FOLDER = BASE_FILE_PATH;
+export const MAINNET_BASE_FOLDER =
+  getPlatform() === 'linux'
+    ? BASE_FILE_PATH
+    : path.join(BASE_FILE_PATH, 'wallets');


### PR DESCRIPTION
- In linux for mainnet wallet.dat is present inside .defi/
- In Mac and window it is inside wallets/ folder